### PR TITLE
fix(parser): name colissions in fns

### DIFF
--- a/packages/parser/src/helpers/bindings.ts
+++ b/packages/parser/src/helpers/bindings.ts
@@ -1,3 +1,26 @@
+export function preventNameCollissions(
+  json: SveltosisComponent,
+  input: string,
+  arguments_: any[],
+  prepend = '',
+  append = '_',
+) {
+  let output = input;
+
+  const keys = [...Object.keys(json.props), ...Object.keys(json.state)];
+
+  for (const key of keys) {
+    if (arguments_.includes(key)) {
+      const regex = new RegExp(`${key}\\b`, 'g');
+      if (regex.test(output)) {
+        output = output.replace(regex, `${prepend}${key}${append}`);
+      }
+    }
+  }
+
+  return output;
+}
+
 export function possiblyAppendPropertiesOrState(json: SveltosisComponent, input: string) {
   let output = input;
 

--- a/packages/parser/src/instance/functions.ts
+++ b/packages/parser/src/instance/functions.ts
@@ -1,11 +1,17 @@
 import { generate } from 'astring';
-import { possiblyAppendPropertiesOrState } from '../helpers/bindings';
+import { possiblyAppendPropertiesOrState, preventNameCollissions } from '../helpers/bindings';
 import type { FunctionDeclaration, Identifier } from 'estree';
 
 export function parseFunctions(json: SveltosisComponent, node: FunctionDeclaration) {
   const id = node.id as Identifier;
+
+  const arguments_ = node.params?.map((parameter) => generate(parameter)) ?? [];
+
   json.state[id.name] = {
-    code: possiblyAppendPropertiesOrState(json, generate(node)),
+    code: possiblyAppendPropertiesOrState(
+      json,
+      preventNameCollissions(json, generate(node), arguments_),
+    ),
     type: 'function',
   };
 }


### PR DESCRIPTION
```
<script>
	let flavours = ['Mint choc chip'];


	function join(flavours) {
		if (flavours.length === 1) return flavours[0];
		return `${flavours.slice(0, -1).join(', ')} and ${flavours[flavours.length - 1]}`;
	}
</script>
```

This is crashing currently as it replaces the arg and its use in the function with state.flavours. The added helper function checks for this and renames the arg by appending "_"