### PR TITLE
feat(parser): add bind group

### DIFF
--- a/packages/fiddle/src/components/Fiddle.tsx
+++ b/packages/fiddle/src/components/Fiddle.tsx
@@ -268,7 +268,7 @@ export default function Fiddle() {
       svelteStateType:
         localStorageGet('options.svelteStateType') || ('variables' as 'variables' | 'proxies'),
       vueApi: localStorageGet('options.vueApi') || ('options' as 'options' | 'composition'),
-      vueVersion: localStorageGet('options.vueVersion') || ('2' as '2' | '3'),
+      vueVersion: localStorageGet('options.vueVersion') || ('3' as '2' | '3'),
     },
 
     async updateOutput() {

--- a/packages/fiddle/src/constants/templates.ts
+++ b/packages/fiddle/src/constants/templates.ts
@@ -150,4 +150,25 @@ export const templates: { [key: string]: string } = {
     }
   </style>
   `,
+  'bind:group': dedent`
+  <script>
+    let tortilla = 'Plain';
+    let fillings = [];
+  </script>
+  <div>
+    <!-- grouped radio inputs are mutually exclusive -->
+    <input type="radio" bind:group={tortilla} value="Plain">
+    <input type="radio" bind:group={tortilla} value="Whole wheat">
+    <input type="radio" bind:group={tortilla} value="Spinach">
+    <br>
+    <br>
+    <!-- grouped checkbox inputs populate an array -->
+    <input type="checkbox" bind:group={fillings} value="Rice">
+    <input type="checkbox" bind:group={fillings} value="Beans">
+    <input type="checkbox" bind:group={fillings} value="Cheese">
+    <input type="checkbox" bind:group={fillings} value="Guac (extra)">
+    <p>Tortilla: {tortilla}</p>
+    <p>Fillings: {fillings}</p>
+  </div>
+  `,
 };

--- a/packages/parser/README.md
+++ b/packages/parser/README.md
@@ -63,7 +63,7 @@ The goal is to support as much of Svelte's syntax as possible, but features list
 | [{@const ...}](https://svelte.dev/docs#template-syntax-const) | todo | -
 | [on:eventname](https://svelte.dev/docs#template-syntax-element-directives-on-eventname) | `ready` | -
  [bind:property](https://svelte.dev/docs#template-syntax-element-directives-bind-property) | `ready` | -
- [bind:group](https://svelte.dev/docs#template-syntax-element-directives-bind-group) | todo | -
+ [bind:group](https://svelte.dev/docs#template-syntax-element-directives-bind-group) | `ready` | -
  [bind:this](https://svelte.dev/docs#template-syntax-element-directives-bind-this) | `ready` | -
  [class:name](https://svelte.dev/docs#template-syntax-element-directives-class-name) | `ready` | -
  [style:property](https://svelte.dev/docs#template-syntax-element-directives-style-property) | `ready` | -

--- a/packages/parser/src/helpers/bindings.ts
+++ b/packages/parser/src/helpers/bindings.ts
@@ -1,0 +1,76 @@
+import { MitosisNode } from '@builder.io/mitosis';
+
+function replaceGroupWithChecked(node: MitosisNode, isArray = false) {
+  if (node.bindings.group?.code?.length) {
+    const bindingValue = node.bindings.value?.code;
+    const propertyValue = node.properties.value;
+    const groupBinding = node.bindings.group.code;
+
+    let code = '';
+
+    if (isArray) {
+      code = bindingValue
+        ? `${groupBinding}.includes(${bindingValue})`
+        : `${groupBinding}.includes('${propertyValue}')`;
+    } else {
+      code = bindingValue
+        ? `${groupBinding} === ${bindingValue}`
+        : `${groupBinding} === '${propertyValue}'`;
+    }
+
+    node.bindings['checked'] = {
+      code,
+    };
+    delete node.bindings.group;
+  }
+}
+
+/* post-processes bindings
+  bind:group https://svelte.dev/docs#template-syntax-element-directives-bind-group
+  bind:property https://svelte.dev/docs#template-syntax-component-directives-bind-this
+  bind:this https://svelte.dev/docs#template-syntax-component-directives-bind-this
+
+  - replaces group binding with checked for checkboxes and radios (supported inputs for bind:group)
+  - adds onChange for bind:group and bind:property (event.target.value OR event.target.checked)
+*/
+export function processBindings(json: SveltosisComponent, node: MitosisNode) {
+  let name;
+  let target = 'event.target.value';
+  let binding = '';
+  let isArray = false;
+
+  if (Object.prototype.hasOwnProperty.call(node.bindings, 'group')) {
+    name = 'group';
+    binding = node.bindings.group?.code ?? '';
+
+    if (binding.startsWith('state.')) {
+      const stateObject = json.state[binding.replace(/^state\./, '')];
+      isArray = Array.isArray(stateObject?.code);
+    }
+
+    replaceGroupWithChecked(node, isArray);
+
+    if (node.properties.type === 'checkbox' && !node.properties.value) {
+      target = 'event.target.checked';
+    }
+  } else if (Object.prototype.hasOwnProperty.call(node.bindings, 'this')) {
+    name = 'ref';
+    binding = node.bindings.this?.code ?? '';
+  }
+
+  let onChangeCode = `${binding} = ${target}`;
+
+  // If the binding is an array, we should push / splice rather than assigning
+  if (isArray) {
+    onChangeCode = `event.target.checked ? ${binding}.push(${target}) : ${binding}.splice(${binding}.indexOf(${
+      node.properties.value ? `'${node.properties.value}'` : node.bindings.value?.code
+    }), 1)`;
+  }
+
+  if (name !== 'ref' && binding) {
+    node.bindings['onChange'] = {
+      code: onChangeCode,
+      arguments: ['event'],
+    };
+  }
+}

--- a/packages/parser/src/helpers/post-process.ts
+++ b/packages/parser/src/helpers/post-process.ts
@@ -1,4 +1,5 @@
 import { extendedHook, MitosisNode, StateValue } from '@builder.io/mitosis';
+import { processBindings } from './bindings';
 
 export function preventNameCollissions(
   json: SveltosisComponent,
@@ -100,6 +101,7 @@ function postProcessState(json: SveltosisComponent) {
 function postProcessChildren(json: SveltosisComponent, children: MitosisNode[]) {
   for (const node of children) {
     addPropertiesAndStateToNode(json, node);
+    processBindings(json, node);
 
     if (node.children?.length) {
       postProcessChildren(json, node.children);

--- a/packages/parser/src/html/element.ts
+++ b/packages/parser/src/html/element.ts
@@ -95,8 +95,15 @@ export function parseElement(json: SveltosisComponent, node: TemplateNode) {
           break;
         }
         case 'Binding': {
+          /* 
+            adding onChange handlers for bind:group and bind:property is done during post processing 
+            same goes for replacing the group binding with checked
+            see helpers/post-process.ts
+          */
+
           const expression = attribute.expression as Identifier;
           const binding = expression.name;
+
           let name = attribute.name;
 
           // template ref
@@ -114,13 +121,6 @@ export function parseElement(json: SveltosisComponent, node: TemplateNode) {
           mitosisNode.bindings[name] = {
             code: binding,
           };
-
-          if (name !== 'ref') {
-            mitosisNode.bindings['onChange'] = {
-              code: `state.${attribute.expression.name} = event.target.value`,
-              arguments: ['event'],
-            };
-          }
 
           break;
         }

--- a/packages/parser/src/instance/context.ts
+++ b/packages/parser/src/instance/context.ts
@@ -33,8 +33,6 @@ export function parseSetContext(json: SveltosisComponent, node: ExpressionStatem
   ) {
     const hook = (node.expression.callee as Identifier).name;
 
-    const argument = node.expression.arguments[0];
-
     if (hook === 'setContext') {
       const key = node.expression.arguments[0] as SimpleLiteral;
       const value = node.expression.arguments[1] as Identifier;


### PR DESCRIPTION
Adds support for [bind:group](https://svelte.dev/docs#template-syntax-element-directives-bind-group)