### PR TITLE
test(parser): add initial tests

### DIFF
--- a/packages/fiddle/src/constants/templates.ts
+++ b/packages/fiddle/src/constants/templates.ts
@@ -171,4 +171,11 @@ export const templates: { [key: string]: string } = {
     <p>Fillings: {fillings}</p>
   </div>
   `,
+  'bind:property': dedent`
+      <script>
+      let value = 'hello';
+    </script>
+
+    <input {value} />
+  `,
 };

--- a/packages/parser/src/html/index.ts
+++ b/packages/parser/src/html/index.ts
@@ -57,10 +57,10 @@ export function parseHtmlNode(
       return parseElement(json, node);
     }
     case 'MustacheTag': {
-      return parseMustacheTag(json, node);
+      return parseMustacheTag(node);
     }
     case 'RawMustacheTag': {
-      return parseRawMustacheTag(json, node);
+      return parseRawMustacheTag(node);
     }
     case 'IfBlock': {
       return parseIfElse(json, node);

--- a/packages/parser/src/html/mustache-tag.ts
+++ b/packages/parser/src/html/mustache-tag.ts
@@ -2,7 +2,7 @@ import { generate } from 'astring';
 import type { TemplateNode } from 'svelte/types/compiler/interfaces';
 import { createMitosisNode } from '../helpers/mitosis-node';
 
-export function parseMustacheTag(json: SveltosisComponent, node: TemplateNode) {
+export function parseMustacheTag(node: TemplateNode) {
   const mitosisNode = createMitosisNode();
   mitosisNode.name = 'div';
   mitosisNode.bindings['_text'] = {
@@ -11,7 +11,7 @@ export function parseMustacheTag(json: SveltosisComponent, node: TemplateNode) {
   return mitosisNode;
 }
 
-export function parseRawMustacheTag(json: SveltosisComponent, node: TemplateNode) {
+export function parseRawMustacheTag(node: TemplateNode) {
   const mitosisNode = createMitosisNode();
   mitosisNode.name = 'div';
   mitosisNode.bindings.innerHTML = {

--- a/packages/parser/src/instance/hooks.ts
+++ b/packages/parser/src/instance/hooks.ts
@@ -1,11 +1,7 @@
 import { generate } from 'astring';
 import type { ExpressionStatement, BaseCallExpression, BaseFunction } from 'estree';
 
-function parseHookBody(
-  json: SveltosisComponent,
-  node: ExpressionStatement,
-  stripCurlyBraces = true,
-) {
+function parseHookBody(node: ExpressionStatement, stripCurlyBraces = true) {
   const arguments_ = (node.expression as BaseCallExpression)?.arguments;
 
   let code = generate((arguments_[0] as BaseFunction).body);
@@ -19,20 +15,20 @@ function parseHookBody(
 
 export function parseOnMount(json: SveltosisComponent, node: ExpressionStatement) {
   json.hooks.onMount = {
-    code: parseHookBody(json, node),
+    code: parseHookBody(node),
   };
 }
 
 export function parseOnDestroy(json: SveltosisComponent, node: ExpressionStatement) {
   json.hooks.onUnMount = {
-    code: parseHookBody(json, node),
+    code: parseHookBody(node),
   };
 }
 
 export function parseAfterUpdate(json: SveltosisComponent, node: ExpressionStatement) {
   json.hooks.onUpdate = [
     {
-      code: parseHookBody(json, node, false),
+      code: parseHookBody(node),
     },
   ];
 }

--- a/packages/parser/test/basic.test.ts
+++ b/packages/parser/test/basic.test.ts
@@ -1,1 +1,0 @@
-import { expect, test } from 'vitest';

--- a/packages/parser/test/bindings.test.ts
+++ b/packages/parser/test/bindings.test.ts
@@ -1,0 +1,92 @@
+import { sveltosis } from '@sveltosis/parser';
+import { expect, test } from 'vitest';
+
+test('bind:group', async () => {
+  const json = await sveltosis(
+    `
+        <script>
+            let tortilla = 'Plain';
+        </script>
+
+        <input type="radio" bind:group={tortilla} value="Plain">
+        <input type="radio" bind:group={tortilla} value="Whole wheat">
+        <input type="radio" bind:group={tortilla} value="Spinach">
+    `,
+    '',
+  );
+  const bindings = json?.children[0].children[0].bindings;
+  const properties = json?.children[0].children[0].properties;
+
+  expect(bindings?.onChange).toBeDefined();
+  expect(bindings?.onChange?.code).toEqual('state.tortilla = event.target.value');
+
+  expect(bindings?.checked).toBeDefined();
+  expect(bindings?.checked?.code).toEqual("state.tortilla === 'Plain'");
+
+  expect(properties?.type).toBeDefined();
+  expect(properties?.type).toBe('radio');
+});
+
+test('bind:group checkbox', async () => {
+  const json = await sveltosis(
+    `
+          <script>
+            let fillings = [];
+          </script>
+  
+          <input type="checkbox" bind:group={fillings} value="Rice">
+          <input type="checkbox" bind:group={fillings} value="Beans">
+          <input type="checkbox" bind:group={fillings} value="Cheese">
+          <input type="checkbox" bind:group={fillings} value="Guac (extra)">
+      `,
+    '',
+  );
+  const bindings = json?.children[0].children[0].bindings;
+
+  expect(bindings?.onChange?.code).toEqual(
+    "event.target.checked ? state.fillings.push(event.target.value) : state.fillings.splice(state.fillings.indexOf('Rice'), 1)",
+  );
+
+  expect(bindings?.checked).toBeDefined();
+  expect(bindings?.checked?.code).toEqual("state.fillings.includes('Rice')");
+});
+
+test('bind:property', async () => {
+  const json = await sveltosis(
+    `
+    <script>
+        let value = 'hello';
+    </script>
+
+    <input {value} />
+`,
+    '',
+  );
+
+  const bindings = json?.children[0].bindings;
+
+  expect(json?.state.value).toBeDefined();
+  expect(json?.state.value?.code).toBe('hello');
+  expect(json?.state.value?.type).toBe('property');
+
+  expect(bindings?.value).toBeDefined();
+  expect(bindings?.value?.code).toEqual('state.value');
+});
+
+test('bind:this', async () => {
+  const json = await sveltosis(
+    `
+    <script>
+        let ref = '';
+    </script>
+    
+    <input bind:this={ref} />
+    `,
+    '',
+  );
+
+  expect(json?.refs.ref).toBeDefined();
+
+  expect(json?.children[0].bindings.ref).toBeDefined();
+  expect(json?.children[0].bindings.ref?.code).toEqual('ref');
+});

--- a/packages/parser/test/context.test.ts
+++ b/packages/parser/test/context.test.ts
@@ -1,0 +1,32 @@
+import { sveltosis } from '@sveltosis/parser';
+import { expect, test } from 'vitest';
+
+const template = `
+<script>
+  import { getContext, setContext } from 'svelte';
+
+  let activeTab = 0;
+
+  let disabled = getContext('disabled');
+
+  setContext('activeTab', activeTab)
+</script>
+
+<div>
+  {activeTab}
+</div>
+`;
+
+test('context:get', async () => {
+  const json = await sveltosis(template, '');
+
+  expect(json?.context.get.disabled).toBeDefined();
+  expect(json?.context.get.disabled.name).toEqual("'disabled'");
+});
+
+test('context:set', async () => {
+  const json = await sveltosis(template, '');
+
+  expect(json?.context.set.activeTab).toBeDefined();
+  expect(json?.context.set.activeTab.ref).toEqual('state.activeTab');
+});

--- a/packages/parser/test/each.test.ts
+++ b/packages/parser/test/each.test.ts
@@ -1,0 +1,17 @@
+import { sveltosis } from '@sveltosis/parser';
+import { expect, test } from 'vitest';
+
+const template = `
+<script>
+  let numbers = ['one', 'two', 'three'];
+</script>
+
+<ul>
+  {#each numbers as num}
+    <li>{num}</li>
+  {/each}
+</ul>`;
+
+test('each', async () => {
+  const json = await sveltosis(template, '');
+});

--- a/packages/parser/test/hooks.test.ts
+++ b/packages/parser/test/hooks.test.ts
@@ -1,0 +1,38 @@
+import { sveltosis } from '@sveltosis/parser';
+import { expect, test } from 'vitest';
+
+const template = `
+<script>
+  import { onMount, onDestroy, onAfterUpdate } from 'svelte';
+
+  onMount(() => {
+    console.log('onMount');
+  });
+
+  onDestroy(() => {
+    console.log('onDestroy');
+  });
+
+  onAfterUpdate(() => {
+    console.log('onAfterUpdate');
+  });
+</script>
+    `;
+
+test('hooks:onMount', async () => {
+  const json = await sveltosis(template, '');
+  expect(json?.hooks.onMount?.code).toEqual("\n  console.log('onMount');\n");
+});
+
+test('hooks:onDestroy', async () => {
+  const json = await sveltosis(template, '');
+  expect(json?.hooks.onUnMount?.code).toEqual("\n  console.log('onDestroy');\n");
+});
+
+test('hooks:onAfterUpdate', async () => {
+  const json = await sveltosis(template, '');
+  expect(json?.hooks.onUpdate?.length || 0).toBeGreaterThan(0);
+  expect(json?.hooks.onUpdate && json.hooks.onUpdate[0].code).toEqual(
+    "\n  console.log('onAfterUpdate');\n",
+  );
+});

--- a/packages/parser/test/if-else.test.ts
+++ b/packages/parser/test/if-else.test.ts
@@ -1,0 +1,32 @@
+import { MitosisNode } from '@builder.io/mitosis';
+import { sveltosis } from '@sveltosis/parser';
+import { expect, test } from 'vitest';
+
+const template = `
+<script>
+  let x = 17
+</script>
+
+{#if x > 10}
+	<p>{x} is greater than 10</p>
+{:else if 5 > x}
+	<p>{x} is less than 5</p>
+{:else}
+	<p>{x} is between 5 and 10</p>
+{/if}
+`;
+
+test('if / else', async () => {
+  const json = await sveltosis(template, '');
+
+  const node = json?.children[0];
+
+  expect(node?.name).toEqual('Show');
+  expect(node?.bindings.when).toBeDefined();
+  expect(node?.bindings.when?.code).toEqual('state.x > 10');
+
+  expect(node?.meta.else).toBeDefined();
+  expect((node?.meta.else as MitosisNode)?.meta?.else).toBeDefined();
+  expect((node?.meta.else as MitosisNode)?.bindings?.when).toBeDefined();
+  expect((node?.meta.else as MitosisNode)?.bindings?.when?.code).toEqual('5 > state.x');
+});

--- a/packages/parser/test/style.test.ts
+++ b/packages/parser/test/style.test.ts
@@ -1,0 +1,9 @@
+import { sveltosis } from '@sveltosis/parser';
+import { expect, test } from 'vitest';
+
+const styleString = `input { font-size: 12px; } \n .form-input:focus { outline: 1px solid blue;} `;
+
+test('style', async () => {
+  const json = await sveltosis(`<style>${styleString}</style>`, '');
+  expect(json?.style).equal(styleString);
+});


### PR DESCRIPTION
Already found an issue when writing these simple tests.

 _FAIL  packages/parser/test/if-else.test.ts > if / else
AssertionError: expected '5 > x' to deeply equal '5 > state.x'
Test Files  1 failed | 5 passed (6)
     Tests  1 failed | 11 passed (12)
  - Expected   "5 > state.x"
  + Received   "5 > x"_

We miss this during post-processing it seems. Opening an issue for this, so ignore that failing test for now


